### PR TITLE
Design: 로그인 페이지 및 메인 페이지(임시) UI 생성

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import { JoinPage } from "./pages/JoinPage/JoinPage";
 import { LoginPage } from "./pages/LoginPage/LoginPage";
+import { MainPage } from "./pages/MainPage/MainPage";
 import GlobalStyles from "./styles/GlobalStyles";
 
 function App() {
@@ -7,8 +8,9 @@ function App() {
     <>
       <GlobalStyles />
       <div className="container">
+        <MainPage />
         {/* <JoinPage /> */}
-        <LoginPage />
+        {/* <LoginPage /> */}
       </div>
     </>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,5 @@
 import { JoinPage } from "./pages/JoinPage/JoinPage";
+import { LoginPage } from "./pages/LoginPage/LoginPage";
 import GlobalStyles from "./styles/GlobalStyles";
 
 function App() {
@@ -6,7 +7,8 @@ function App() {
     <>
       <GlobalStyles />
       <div className="container">
-        <JoinPage />
+        {/* <JoinPage /> */}
+        <LoginPage />
       </div>
     </>
   );

--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -1,7 +1,15 @@
 import React from "react";
 import styled from "styled-components";
 
-export const Input = ({ type, name, value, onChange, placeholder, errors }) => {
+export const Input = ({
+  join,
+  type,
+  name,
+  value,
+  onChange,
+  placeholder,
+  errors,
+}) => {
   return (
     <InputWrap>
       <InputBox
@@ -11,7 +19,7 @@ export const Input = ({ type, name, value, onChange, placeholder, errors }) => {
         onChange={onChange}
         placeholder={placeholder}
       />
-      {errors[name] && <ErrorText>{errors[name]}</ErrorText>}
+      {join && errors[name] && <ErrorText>{errors[name]}</ErrorText>}
     </InputWrap>
   );
 };

--- a/src/components/JoinForm/JoinForm.jsx
+++ b/src/components/JoinForm/JoinForm.jsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from "react";
+
 import { useForm } from "../../hooks/useForm";
 import { Input } from "../Input/Input";
 import { validate } from "../../utils/validate";
+
 import * as S from "./styles";
 
 export const JoinForm = () => {

--- a/src/components/JoinForm/styles.js
+++ b/src/components/JoinForm/styles.js
@@ -1,7 +1,6 @@
 import styled from "styled-components";
 
 export const FormWrap = styled.form`
-  max-width: 300px;
   display: flex;
   flex-direction: column;
 `;

--- a/src/components/Login/LoginForm.jsx
+++ b/src/components/Login/LoginForm.jsx
@@ -1,22 +1,19 @@
 import React, { useEffect, useState } from "react";
 import { useForm } from "../../hooks/useForm";
 import { Input } from "../Input/Input";
-import { validate } from "../../utils/validate";
 import * as S from "./styles";
 
-export const JoinForm = () => {
+export const LoginForm = () => {
   const { values, handleChange } = useForm(initailValues);
   const [isChecked, setIsChecked] = useState(false);
 
-  const errors = validate(values);
-
   useEffect(() => {
-    if (!errors.email && !errors.password) {
+    if (values.email && values.password) {
       setIsChecked(true);
     } else {
       setIsChecked(false);
     }
-  }, [errors, setIsChecked]);
+  }, [values, setIsChecked]);
 
   return (
     <S.FormWrap>
@@ -26,27 +23,23 @@ export const JoinForm = () => {
         placeholder="todo@email.com"
         value={values}
         onChange={handleChange}
-        errors={errors}
-        join
       />
       <Input
         data-testid="password-input"
         name="password"
         type="password"
-        placeholder="비밀번호는 8자 이상 입력해주세요."
+        placeholder="비밀번호를 입력해주세요."
         value={values}
         onChange={handleChange}
-        errors={errors}
-        join
       />
 
       <S.SubmitButton
-        data-testid="signup-button"
+        data-testid="signin-button"
         type="submit"
         disabled={!isChecked}
         className={`${isChecked ? "" : "disable"}`}
       >
-        가입하기
+        로그인 하기
       </S.SubmitButton>
     </S.FormWrap>
   );

--- a/src/components/Login/LoginForm.jsx
+++ b/src/components/Login/LoginForm.jsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from "react";
+
 import { useForm } from "../../hooks/useForm";
 import { Input } from "../Input/Input";
+
 import * as S from "./styles";
 
 export const LoginForm = () => {

--- a/src/components/Login/styles.js
+++ b/src/components/Login/styles.js
@@ -1,7 +1,6 @@
 import styled from "styled-components";
 
 export const FormWrap = styled.form`
-  max-width: 300px;
   display: flex;
   flex-direction: column;
 `;

--- a/src/components/Login/styles.js
+++ b/src/components/Login/styles.js
@@ -1,0 +1,27 @@
+import styled from "styled-components";
+
+export const FormWrap = styled.form`
+  max-width: 300px;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const SubmitButton = styled.button`
+  padding: 7px 5px;
+  margin-top: 40px;
+
+  border: none;
+  border-radius: 6px;
+
+  color: #fff;
+  background-color: #009dff;
+  cursor: pointer;
+
+  &.disable {
+    border: 1px solid #a0a0a0;
+
+    color: #898989;
+    background-color: #eaeaea;
+    cursor: default;
+  }
+`;

--- a/src/pages/LoginPage/LoginPage.jsx
+++ b/src/pages/LoginPage/LoginPage.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { LoginForm } from "../../components/Login/LoginForm";
+
+import * as S from "./styles";
+
+export const LoginPage = () => {
+  return (
+    <S.PageContainer>
+      <S.PageTitle>로그인 정보를 입력해주세요!🙇‍♀️</S.PageTitle>
+      <LoginForm />
+    </S.PageContainer>
+  );
+};

--- a/src/pages/LoginPage/styles.js
+++ b/src/pages/LoginPage/styles.js
@@ -10,8 +10,8 @@ export const PageContainer = styled.div`
 `;
 
 export const PageTitle = styled.h1`
-  margin-bottom: 25px;
+  margin-bottom: 30px;
 
   font-size: 22px;
-  font-weight: blod;
+  font-weight: bold;
 `;

--- a/src/pages/LoginPage/styles.js
+++ b/src/pages/LoginPage/styles.js
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+
+export const PageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  height: 100%;
+`;
+
+export const PageTitle = styled.h1`
+  margin-bottom: 25px;
+
+  font-size: 22px;
+  font-weight: blod;
+`;

--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+import * as S from "./styles";
+
+export const MainPage = () => {
+  return (
+    <S.PageContainer>
+      <S.PageTitle>What is your plan?</S.PageTitle>
+      <S.IconWrap>
+        <button>로그인</button>
+        <button>회원가입</button>
+      </S.IconWrap>
+    </S.PageContainer>
+  );
+};

--- a/src/pages/MainPage/styles.js
+++ b/src/pages/MainPage/styles.js
@@ -10,8 +10,10 @@ export const PageContainer = styled.div`
 `;
 
 export const PageTitle = styled.h1`
-  margin-bottom: 30px;
+  margin-bottom: 25px;
 
-  font-size: 22px;
+  font-size: 35px;
   font-weight: bold;
 `;
+
+export const IconWrap = styled.div``;


### PR DESCRIPTION
### 구현 사항

- [x] 로그인 페이지 UI 생성
- [x] 임시 메인 페이지 UI 생성
  - 라우터 설정을 위해 임시 디자인으로 생성(디자인 변경 예정)

### 참고 사항

- Input 컴포넌트 재활용을 위해 join props를 추가
  - 별도의 구분이 없으면 로그인 페이지에서도 에러방지를 위해 필요없는 `errors=""`라는 prop을 넘겨야함
  - join prop이 있을 때만 errors prop활용하도록 작성
